### PR TITLE
Add "name", "version", and "bin" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,14 @@
 {
+  "name": "solid-cli",
+  "version": "1.0.0",
   "author": "Ruben Verborgh <ruben@verborgh.org> (https://ruben.verborgh.org/)",
   "license": "MIT",
   "scripts": {
     "lint": "eslint src bin/*",
     "test": "npm run lint"
+  },
+  "bin": {
+    "solid-bearer-token": "./bin/solid-bearer-token"
   },
   "dependencies": {
     "@trust/oidc-rp": "0.6.0"


### PR DESCRIPTION
These additions allow the package to be npm link'ed or npm-installed globally, in a way that makes the solid-bearer-token utility useable on the system.